### PR TITLE
fix aof output support

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -338,13 +338,18 @@ static void TDigestTypeAofRewrite(RedisModuleIO *aof, RedisModuleString *key,
     struct TDigest *t = value;
     int i;
 
-    RedisModule_EmitAOF(aof, "TDIGEST.NEW", "%s %ll", key, t->compression);
+    char dbuf[128];
+    unsigned int dlen;
+    dlen = snprintf(dbuf, sizeof(dbuf), "%.17g", t->compression);
+
+    RedisModule_EmitAOF(aof, "TDIGEST.NEW", "sb", key, dbuf, dlen);
 
     tdigestCompress(t);
 
     for (i = 0; i < t->num_centroids; i++) {
         struct Centroid *c = &t->centroids[i];
-        RedisModule_EmitAOF(aof, "TDIGEST.ADD", "%s %f %ll", key, c->mean,
+        dlen = snprintf(dbuf, sizeof(dbuf), "%.17g", c->mean);
+        RedisModule_EmitAOF(aof, "TDIGEST.ADD", "sbl", key, dbuf, dlen,
                 c->weight);
     }
 }

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -153,3 +153,19 @@ def test_mem_leak(redis, flushdb):
   # %age difference should be < 1%
   percent_diff = abs(end_rss_mem - start_rss_mem) / float(end_rss_mem)
   assert percent_diff < 0.01
+
+
+def run_persistence_test(redis, reloadfn):
+  redis.tdigest_new('test_aof0')
+  for i in xrange(10):
+    redis.tdigest_add('test_aof0', i, 1)
+  assert redis.client.type('test_aof0') == 't-digest0'
+  reloadfn()
+  assert redis.client.type('test_aof0') == 't-digest0'
+
+
+def test_aof(redis, flushdb):
+  run_persistence_test(redis, redis.reload_from_aof)
+
+def test_rdb(redis, flushdb):
+  run_persistence_test(redis, redis.reload_from_rdb)


### PR DESCRIPTION
This module was expecting to use EmitAOF's fmt string like sprintf, but
redis modules have their own string format (see
`moduleCreateArgvFromUserFormat` in the Redis source).

Notably there is no built-in support for writing doubles, so this change
dumps double values to a buffer before the EmitAOF calls.